### PR TITLE
remove hardcoded loglevel

### DIFF
--- a/services/htpcmanager/run
+++ b/services/htpcmanager/run
@@ -1,3 +1,3 @@
 #!/bin/bash
-/sbin/setuser abc python /app/htpcmanager/Htpc.py --loglevel info --datadir /config
+/sbin/setuser abc python /app/htpcmanager/Htpc.py --datadir /config
 


### PR DESCRIPTION
This overrides any settings in the db and makes it impossible for the user to change loglevel settings.
